### PR TITLE
new surface model for EMIT v2 reflectance

### DIFF
--- a/surface/surface_20260113.json
+++ b/surface/surface_20260113.json
@@ -1,0 +1,112 @@
+{
+  "output_model_file": "surface_20240103_emit_REE.mat",
+  "wavelength_file":   "emit_wavelength_fit.txt",
+  "normalize":"Euclidean",
+  "reference_windows":[[400,1250],[1500,1700],[2100,2450]],
+  "sources":
+    [
+      {
+        "input_spectrum_files":
+          [
+            "filtered_other"
+          ],
+        "n_components": 1,
+        "windows": [
+          {"interval":[300,750], "regularizer":1e-2, "correlation":"EM","name":"uv-nir"},
+          {"interval":[750,770], "regularizer":1e-6, "correlation":"EM", "name":"O2-band"},
+          {"interval":[770,909], "regularizer":1e-2, "correlation":"EM","name":"nir"},
+          {"interval":[909,920], "regularizer":1e-4, "correlation":"EM", "name":"shallow-water-A"},
+          {"interval":[920,940], "regularizer":1e-5, "correlation":"EM", "name":"shallow-water-B"},
+          {"interval":[940,1250], "regularizer":1e-6, "correlation":"EM", "name":"shallow-water-C"},
+          {"interval":[1250,1325], "regularizer":1e-8, "correlation":"EM", "name": "osf"},
+          {"interval":[1325,1400], "regularizer":10, "correlation": "decorrelated","name":"deep-water-A"},
+          {"interval":[1400,1500], "regularizer":1e-4, "correlation": "EM","name":"deep-water-A-edge"},
+          {"interval":[1500,1820], "regularizer":1e-2, "correlation": "EM","name":"swir1"},
+          {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
+          {"interval":[1960,2090], "regularizer":1e-5, "correlation":"EM","name": "co2"},
+          {"interval":[2090,2300], "regularizer":1e-2, "correlation":"EM","name":"swir2"},
+          {"interval":[2300,2470], "regularizer":1e-3, "correlation":"EM", "name": "noise" },
+          {"interval":[2470,2500], "regularizer":1e-8, "correlation":"EM", "name": "noise" }
+        ]
+      },
+      {
+        "input_spectrum_files":
+          [
+            "surface_mixture_veg_soil"
+          ],
+        "n_components": 2,
+        "windows": [
+          {"interval":[300,740], "regularizer":1e-4, "correlation":"EM","name":"uv-nir"},
+          {"interval":[740,1250], "regularizer":1e-6, "correlation":"EM", "name":"shallow-water"},
+          {"interval":[1250,1325], "regularizer":1e-8, "correlation":"EM", "name": "osf"},
+          {"interval":[1325,1400], "regularizer":10, "correlation": "decorrelated","name":"deep-water-A"},
+          {"interval":[1400,1500], "regularizer":1e-4, "correlation": "EM","name":"deep-water-A-edge"},
+          {"interval":[1500,1820], "regularizer":1e-2, "correlation": "EM","name":"swir1"},
+          {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
+          {"interval":[1960,2090], "regularizer":1e-5, "correlation":"EM","name": "co2"},
+          {"interval":[2090,2470], "regularizer":1e-3, "correlation":"EM","name":"swir2"},
+          {"interval":[2470,2500], "regularizer":1e-8, "correlation":"EM", "name": "noise" }
+        ]
+      },
+      {
+        "input_spectrum_files":
+          [
+            "filtered_veg"
+          ],
+        "n_components": 1,
+        "windows": [
+          {"interval":[300,350], "regularizer":1e-2, "correlation":"EM"},
+          {"interval":[350,500], "regularizer":1e-6, "correlation":"EM","name":"aerosol"},
+          {"interval":[500,750], "regularizer":1e-4, "correlation":"EM","name":"vis"},
+          {"interval":[750,1250], "regularizer":1e-6, "correlation":"EM", "name":"shallow-water"},
+          {"interval":[1250,1325], "regularizer":1e-8, "correlation":"EM", "name": "osf"},
+          {"interval":[1325,1400], "regularizer":10, "correlation": "decorrelated","name":"deep-water-A"},
+          {"interval":[1400,1500], "regularizer":1e-4, "correlation": "EM","name":"deep-water-A-edge"},
+          {"interval":[1500,1820], "regularizer":1e-2, "correlation": "EM","name":"swir1"},
+          {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
+          {"interval":[1960,2070], "regularizer":1e-5, "correlation":"EM","name": "co2"},
+          {"interval":[2070,2470], "regularizer":1e-3, "correlation":"EM","name":"swir2"},
+          {"interval":[2470,2500], "regularizer":1e-8, "correlation":"EM", "name": "noise" }
+        ]
+      },
+      {
+        "input_spectrum_files":
+          [
+            "filtered_ocean"
+          ],
+        "n_components": 1,
+        "windows": [
+          {"interval":[300,880], "regularizer":10, "correlation":"decorrelated"},
+          {"interval":[880,1250], "regularizer":1e-6, "correlation":"EM", "name": "nir"},
+          {"interval":[1250,1325], "regularizer":1e-6, "correlation":"EM", "name": "osf"},
+          {"interval":[1325,1400], "regularizer":10, "correlation": "decorrelated","name":"deep-water-A"},
+          {"interval":[1400,1820], "regularizer":1e-6, "correlation": "EM","name":"swir1"},
+          {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
+          {"interval":[1960,2500], "regularizer":1e-6, "correlation": "EM", "name":"swir2"}
+        ]
+      },
+      {
+        "input_spectrum_files":
+          [
+            "surface_Liquids"
+          ],
+        "n_components": 2,
+        "windows": [
+          {"interval":[300,750], "regularizer":1e-2, "correlation":"EM","name":"uv-nir"},
+          {"interval":[750,770], "regularizer":1e-6, "correlation":"EM", "name":"O2-band"},
+          {"interval":[770,880], "regularizer":1e-2, "correlation":"EM","name":"nir"},
+          {"interval":[880,920], "regularizer":1e-4, "correlation":"EM", "name":"shallow-water-A"},
+          {"interval":[920,940], "regularizer":1e-5, "correlation":"EM", "name":"shallow-water-B"},
+          {"interval":[940,1250], "regularizer":1e-6, "correlation":"EM", "name":"shallow-water-C"},
+          {"interval":[1250,1325], "regularizer":1e-8, "correlation":"EM", "name": "osf"},
+          {"interval":[1325,1400], "regularizer":10, "correlation": "decorrelated","name":"deep-water-A"},
+          {"interval":[1400,1500], "regularizer":1e-4, "correlation": "EM","name":"deep-water-A-edge"},
+          {"interval":[1500,1820], "regularizer":1e-2, "correlation": "EM","name":"swir1"},
+          {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
+          {"interval":[1960,2070], "regularizer":1e-5, "correlation":"EM","name": "co2"},
+          {"interval":[2070,2470], "regularizer":1e-4, "correlation":"EM","name":"swir2"},
+          {"interval":[2470,2500], "regularizer":1e-8, "correlation":"EM",  "name": "noise" }
+        ]
+      }
+  ]
+}

--- a/surface/surface_20260113.json
+++ b/surface/surface_20260113.json
@@ -23,7 +23,7 @@
           {"interval":[1400,1500], "regularizer":1e-4, "correlation": "EM","name":"deep-water-A-edge"},
           {"interval":[1500,1820], "regularizer":1e-2, "correlation": "EM","name":"swir1"},
           {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
-          {"interval":[1960,2090], "regularizer":1e-5, "correlation":"EM","name": "co2"},
+          {"interval":[1960,2090], "regularizer":1e-4, "correlation":"EM","name": "co2"},
           {"interval":[2090,2300], "regularizer":1e-2, "correlation":"EM","name":"swir2"},
           {"interval":[2300,2470], "regularizer":1e-3, "correlation":"EM", "name": "noise" },
           {"interval":[2470,2500], "regularizer":1e-8, "correlation":"EM", "name": "noise" }
@@ -43,7 +43,7 @@
           {"interval":[1400,1500], "regularizer":1e-4, "correlation": "EM","name":"deep-water-A-edge"},
           {"interval":[1500,1820], "regularizer":1e-2, "correlation": "EM","name":"swir1"},
           {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
-          {"interval":[1960,2090], "regularizer":1e-5, "correlation":"EM","name": "co2"},
+          {"interval":[1960,2090], "regularizer":1e-4, "correlation":"EM","name": "co2"},
           {"interval":[2090,2470], "regularizer":1e-3, "correlation":"EM","name":"swir2"},
           {"interval":[2470,2500], "regularizer":1e-8, "correlation":"EM", "name": "noise" }
         ]
@@ -64,7 +64,7 @@
           {"interval":[1400,1500], "regularizer":1e-4, "correlation": "EM","name":"deep-water-A-edge"},
           {"interval":[1500,1820], "regularizer":1e-2, "correlation": "EM","name":"swir1"},
           {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
-          {"interval":[1960,2070], "regularizer":1e-5, "correlation":"EM","name": "co2"},
+          {"interval":[1960,2070], "regularizer":1e-4, "correlation":"EM","name": "co2"},
           {"interval":[2070,2470], "regularizer":1e-3, "correlation":"EM","name":"swir2"},
           {"interval":[2470,2500], "regularizer":1e-8, "correlation":"EM", "name": "noise" }
         ]
@@ -76,7 +76,7 @@
           ],
         "n_components": 1,
         "windows": [
-          {"interval":[300,880], "regularizer":10, "correlation":"decorrelated"},
+          {"interval":[300,880], "regularizer":10, "correlation":"EM"},
           {"interval":[880,1250], "regularizer":1e-6, "correlation":"EM", "name": "nir"},
           {"interval":[1250,1325], "regularizer":1e-6, "correlation":"EM", "name": "osf"},
           {"interval":[1325,1400], "regularizer":10, "correlation": "decorrelated","name":"deep-water-A"},
@@ -103,7 +103,7 @@
           {"interval":[1400,1500], "regularizer":1e-4, "correlation": "EM","name":"deep-water-A-edge"},
           {"interval":[1500,1820], "regularizer":1e-2, "correlation": "EM","name":"swir1"},
           {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
-          {"interval":[1960,2070], "regularizer":1e-5, "correlation":"EM","name": "co2"},
+          {"interval":[1960,2070], "regularizer":1e-4, "correlation":"EM","name": "co2"},
           {"interval":[2070,2470], "regularizer":1e-4, "correlation":"EM","name":"swir2"},
           {"interval":[2470,2500], "regularizer":1e-8, "correlation":"EM",  "name": "noise" }
         ]


### PR DESCRIPTION
Surface model configuration for EMIT v2 reflectance.  
Primary changes:
- removes tau feathering, which can be numerically unstable, in favor of off-diagonal blocks to prevent reflectance discontinuities between spectral windows (i.e. the "EM" correlation option)
- looser prior in the VIS-NIR for soil and rock surfaces, to prevent suppression of rare earth element signatures