### PR TITLE
Loosened SWIR prior constraint for ocean library and NIR prior constraint for mixed soil-vegetation

### DIFF
--- a/surface/surface_20260113.json
+++ b/surface/surface_20260113.json
@@ -76,13 +76,13 @@
           ],
         "n_components": 1,
         "windows": [
-          {"interval":[300,880], "regularizer":10, "correlation":"EM"},
-          {"interval":[880,1250], "regularizer":1e-6, "correlation":"EM", "name": "nir"},
+          {"interval":[300,880], "regularizer":10, "correlation":"decorrelated"},
+          {"interval":[880,1250], "regularizer":1e-5, "correlation":"EM", "name": "nir"},
           {"interval":[1250,1325], "regularizer":1e-6, "correlation":"EM", "name": "osf"},
           {"interval":[1325,1400], "regularizer":10, "correlation": "decorrelated","name":"deep-water-A"},
-          {"interval":[1400,1820], "regularizer":1e-6, "correlation": "EM","name":"swir1"},
-          {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
-          {"interval":[1960,2500], "regularizer":1e-6, "correlation": "EM", "name":"swir2"}
+          {"interval":[1400,1820], "regularizer":1e-4, "correlation": "EM","name":"swir1"},
+          {"interval":[1820,1980], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
+          {"interval":[1980,2600], "regularizer":1e-4, "correlation": "EM", "name":"swir2"}
         ]
       },
       {

--- a/surface/surface_20260113.json
+++ b/surface/surface_20260113.json
@@ -36,16 +36,20 @@
           ],
         "n_components": 2,
         "windows": [
-          {"interval":[300,740], "regularizer":1e-4, "correlation":"EM","name":"uv-nir"},
-          {"interval":[740,1250], "regularizer":1e-6, "correlation":"EM", "name":"shallow-water"},
-          {"interval":[1250,1325], "regularizer":1e-8, "correlation":"EM", "name": "osf"},
+          {"interval":[300,750], "regularizer":1e-1, "correlation":"decorrelated","name":"uv-nir"},
+          {"interval":[750,770], "regularizer":1e-6, "correlation":"EM", "name":"O2-band"},
+          {"interval":[770,909], "regularizer":1e-1, "correlation":"decorrelated","name":"nir"},
+          {"interval":[909,920], "regularizer":1e-4, "correlation":"EM", "name":"shallow-water-A"},
+          {"interval":[920,940], "regularizer":1e-5, "correlation":"EM", "name":"shallow-water-B"},
+          {"interval":[940,1250], "regularizer":1e-5, "correlation":"EM", "name":"shallow-water-C"},
+          {"interval":[1250,1325], "regularizer":1e-7, "correlation":"EM", "name": "osf"},
           {"interval":[1325,1400], "regularizer":10, "correlation": "decorrelated","name":"deep-water-A"},
           {"interval":[1400,1500], "regularizer":1e-4, "correlation": "EM","name":"deep-water-A-edge"},
           {"interval":[1500,1820], "regularizer":1e-2, "correlation": "EM","name":"swir1"},
           {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
           {"interval":[1960,2090], "regularizer":1e-4, "correlation":"EM","name": "co2"},
           {"interval":[2090,2470], "regularizer":1e-3, "correlation":"EM","name":"swir2"},
-          {"interval":[2470,2500], "regularizer":1e-8, "correlation":"EM", "name": "noise" }
+          {"interval":[2470,2600], "regularizer":1e-8, "correlation":"EM", "name": "noise" }
         ]
       },
       {


### PR DESCRIPTION
The 1e-6 regularizer in the SWIR was causing prior locking. Additionally, I tested two components and found it had minimal impact. With the delicate prior selection over water, I chose to keep n_components = 1.

Some figures supporting the water library changes:

<img width="1836" height="891" alt="image" src="https://github.com/user-attachments/assets/481633c3-9a7a-4f6a-a79b-8b91815cae63" />

Figure supporting the mixed prior changes:

<img width="1179" height="433" alt="image" src="https://github.com/user-attachments/assets/23590030-612b-4cd4-807d-bc91a8f3f40f" />

