### PR TITLE
support potential alunite detection in 1400-1500

### DIFF
--- a/surface/surface_20260113.json
+++ b/surface/surface_20260113.json
@@ -20,7 +20,7 @@
           {"interval":[940,1250], "regularizer":1e-6, "correlation":"EM", "name":"shallow-water-C"},
           {"interval":[1250,1325], "regularizer":1e-8, "correlation":"EM", "name": "osf"},
           {"interval":[1325,1400], "regularizer":10, "correlation": "decorrelated","name":"deep-water-A"},
-          {"interval":[1400,1500], "regularizer":1e-4, "correlation": "EM","name":"deep-water-A-edge"},
+          {"interval":[1400,1500], "regularizer":1e-2, "correlation": "EM","name":"deep-water-A-edge"},
           {"interval":[1500,1820], "regularizer":1e-2, "correlation": "EM","name":"swir1"},
           {"interval":[1820,1960], "regularizer":10, "correlation": "decorrelated","name":"deep-water-B"},
           {"interval":[1960,2090], "regularizer":1e-4, "correlation":"EM","name": "co2"},


### PR DESCRIPTION
<img width="808" height="409" alt="image" src="https://github.com/user-attachments/assets/3eae2589-5e2f-4772-8ea3-b0d923dfe118" />

change takes us from red to light blue, sacrificing water vapor residuals for potential mineral detections in the 1400-1500 region.